### PR TITLE
Changed add_funding function to return award not parent element 

### DIFF
--- a/R/funding-element.R
+++ b/R/funding-element.R
@@ -1,6 +1,6 @@
 #' @title Add Funding Element
-#' @description Adds the funding information of a dataset based off of EML standards. 
-#' @param parent_element A list representing the EML project or dataset.
+#' @description Creates the award information of a project based off of EML standards. 
+#' This award element is then nested within a project node to complete a funding section. 
 #' @param funder_name Organization or individual providing the funding.
 #' @param funder_identifier This is where the funding organization is listed in 
 #' the registry. The funder identifier must be registered. Follow the instructions at 
@@ -10,9 +10,9 @@
 #' @param award_url Optional to include a link to information about the funding
 #'  award on the funding organization's webpage.
 #' @param funding_description Optional to provide a short description of the funding recieved.
-#' @return The dataset or project with funding information appended. 
+#' @return An award list that is then added to the project element of an EML file.  
 #' @examples 
-#' add_funding(parent_element = list(), funder_name = "National Science Foundation",
+#' add_funding(funder_name = "National Science Foundation",
 #'             funder_identifier = "http://dx.doi.org/10.13039/100000001",
 #'             award_number = "1656026",
 #'             award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",
@@ -22,12 +22,14 @@
 #'                                    (2017-08-01 to 2022-07-31)." )
 #' @export
 
-add_funding <- function(parent_element, funder_name, funder_identifier, award_number,
-                        award_title, award_url = NULL, funding_description = NULL)  {
+add_funding <- function(funder_name, funder_identifier, award_number,
+                        award_title, project_title, project_personnel, 
+                        award_url = NULL, funding_description = NULL)  {
   
-  
+  award <- list()
   required_arguments <- c("funder_name", "funder_identifier", "award_number",
-                      "award_title", "award_url", "funding_description")
+                          "award_title", "award_url", "funding_description")
+  
   missing_argument_index <- which(c(missing(funder_name), missing(funder_identifier),
                               missing(award_number), missing(award_title), 
                               missing(award_url), missing(funding_description)))
@@ -37,7 +39,7 @@ add_funding <- function(parent_element, funder_name, funder_identifier, award_nu
     fund_error_message <- switch(fund_error, funder_name = "Please provide funders name.",
                                  funder_identifier = "Please provide funder identifier link.",
                                  award_number = "Please provide your award number.", 
-                                 award_title = "Please provide the title of your project.",
+                                 award_title = "Please provide the title of your award.",
                                  award_url = "Please provide the award url.",
                                  funding_description = "Please provide the description of the funding recieved.")
     if (missing(funder_name) | missing(funder_identifier) |
@@ -49,20 +51,21 @@ add_funding <- function(parent_element, funder_name, funder_identifier, award_nu
       warning(fund_error_message, call. = FALSE)
     }
   }
-  if (!is.null(funding_description)) {
-    parent_element$funding = list(para = funding_description)
-  }
+  award <- list(funderName = funder_name,
+                funderIdentifier = funder_identifier,
+                awardNumber = award_number, 
+                title = award_title)
   
-  parent_element$award <- list(funderName = funder_name,
-                               funderIdentifier = funder_identifier,
-                               awardNumber = award_number, 
-                               title = award_title)
+  if (!is.null(funding_description)) {
+    award$description = funding_description
+
+  }
   
   if (!is.null(award_url)) {
-    parent_element$award$awardUrl <- award_url
+    award$awardUrl <- award_url
   }
   
-  return(parent_element)
+  return(award)
 }
 
 

--- a/R/funding-element.R
+++ b/R/funding-element.R
@@ -23,8 +23,7 @@
 #' @export
 
 add_funding <- function(funder_name, funder_identifier, award_number,
-                        award_title, project_title, project_personnel, 
-                        award_url = NULL, funding_description = NULL)  {
+                        award_title, award_url = NULL, funding_description = NULL)  {
   
   award <- list()
   required_arguments <- c("funder_name", "funder_identifier", "award_number",

--- a/man/add_funding.Rd
+++ b/man/add_funding.Rd
@@ -5,18 +5,17 @@
 \title{Add Funding Element}
 \usage{
 add_funding(
-  parent_element,
   funder_name,
   funder_identifier,
   award_number,
   award_title,
+  project_title,
+  project_personnel,
   award_url = NULL,
   funding_description = NULL
 )
 }
 \arguments{
-\item{parent_element}{A list representing the EML project or dataset.}
-
 \item{funder_name}{Organization or individual providing the funding.}
 
 \item{funder_identifier}{This is where the funding organization is listed in
@@ -33,13 +32,14 @@ award on the funding organization's webpage.}
 \item{funding_description}{Optional to provide a short description of the funding recieved.}
 }
 \value{
-The dataset or project with funding information appended.
+An award list that is then added to the project element of an EML file.
 }
 \description{
-Adds the funding information of a dataset based off of EML standards.
+Creates the award information of a project based off of EML standards.
+This award element is then nested within a project node to complete a funding section.
 }
 \examples{
-add_funding(parent_element = list(), funder_name = "National Science Foundation",
+add_funding(funder_name = "National Science Foundation",
             funder_identifier = "http://dx.doi.org/10.13039/100000001",
             award_number = "1656026",
             award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",

--- a/man/add_funding.Rd
+++ b/man/add_funding.Rd
@@ -9,8 +9,6 @@ add_funding(
   funder_identifier,
   award_number,
   award_title,
-  project_title,
-  project_personnel,
   award_url = NULL,
   funding_description = NULL
 )

--- a/tests/testthat/test-eml-elements.R
+++ b/tests/testthat/test-eml-elements.R
@@ -152,43 +152,43 @@ test_that('personnel function errors when missing mandatory identifier inputs', 
 
 test_that('funding function errors when missing mandatory identifier inputs', {
   
-  expect_error(add_funding(parent_element = list(), 
-                           funder_identifier = "http://dx.doi.org/10.13039/100000001",
+  expect_error(add_funding(funder_identifier = "http://dx.doi.org/10.13039/100000001",
                            award_number = "1656026",
                            award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",
                            award_url = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1656026",
                            funding_description = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31)." ), 
                "Please provide funders name.")
   
-  expect_error(add_funding(parent_element = list(), funder_name = "National Science Foundation",
+  expect_error(add_funding(funder_name = "National Science Foundation",
                            award_number = "1656026",
                            award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",
                            award_url = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1656026",
                            funding_description = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31)." ),
                "Please provide funder identifier link.")
   
-  expect_error(add_funding(parent_element = list(), funder_name = "National Science Foundation",
+  expect_error(add_funding(funder_name = "National Science Foundation",
                            funder_identifier = "http://dx.doi.org/10.13039/100000001",
                            award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",
                            award_url = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1656026",
                            funding_description = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31)." ),
                "Please provide your award number.")
   
-  expect_error(add_funding(parent_element = list(), funder_name = "National Science Foundation",
+  expect_error(add_funding(funder_name = "National Science Foundation",
                            funder_identifier = "http://dx.doi.org/10.13039/100000001",
                            award_number = "1656026",
                            award_url = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1656026",
                            funding_description = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31)." ),
-               "Please provide the title of your project.")
+               "Please provide the title of your award.")
+
   
-  expect_warning(add_funding(parent_element = list(), funder_name = "National Science Foundation",
+  expect_warning(add_funding(funder_name = "National Science Foundation",
                              funder_identifier = "http://dx.doi.org/10.13039/100000001",
                              award_number = "1656026",
                              award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",
                              funding_description = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31)." ),
                  "Please provide the award url.")
   
-  expect_warning(add_funding(parent_element = list(), funder_name = "National Science Foundation",
+  expect_warning(add_funding(funder_name = "National Science Foundation",
                              funder_identifier = "http://dx.doi.org/10.13039/100000001",
                              award_number = "1656026",
                              award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",
@@ -200,19 +200,18 @@ test_that('funding function errors when missing mandatory identifier inputs', {
 
 test_that('The add_funding function adds the funding elements', {
   
-  expect_equal(add_funding(parent_element = list(), funder_name = "National Science Foundation",
+  expect_equal(add_funding(funder_name = "National Science Foundation",
                            funder_identifier = "http://dx.doi.org/10.13039/100000001",
                            award_number = "1656026",
                            award_title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition",
                            award_url = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1656026",
                            funding_description = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31)."),
-               list(funding = list(para = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31)."), 
-                    award = list(funderName = "National Science Foundation", 
-                                 funderIdentifier = "http://dx.doi.org/10.13039/100000001", 
-                                 awardNumber = "1656026", title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition", 
-                                 awardUrl = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1656026"))
-  )
-  
+                    list(funderName = "National Science Foundation", 
+                         funderIdentifier = "http://dx.doi.org/10.13039/100000001", 
+                         awardNumber = "1656026", 
+                         title = "LTER: Beaufort Sea Lagoons: An Arctic Coastal Ecosystem in Transition", 
+                         description = "BLE LTER is supported by the National Science Foundation under award #1656026 (2017-08-01 to 2022-07-31).",
+                         awardUrl = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1656026"))
 })
 
 #Tests for add_license function 


### PR DESCRIPTION
The add_funding function was adding the award section to the parent element. Award should be nested under a project node that is within parent element. To fix this I am making the add_funding function return an award list. This award list will be added into the project node along with the other required project elements. 