### PR TITLE
Changed add personnel function to make organization a required element

### DIFF
--- a/R/personnel-element.R
+++ b/R/personnel-element.R
@@ -7,10 +7,10 @@
 #' @param first_name Person's given name
 #' @param last_name Person's surname
 #' @param email Person's email address
-#' @param orcid ORCID iD is a persistent digital identifier for researchers,
-#' register at \url{http://orcid.org/}
 #' @param organization Person's employer or the entity they are associated
 #' with for this dataset or project
+#' @param orcid ORCID iD is a persistent digital identifier for researchers,
+#' register at \url{http://orcid.org/}
 #' @examples 
 #' add_personnel(parent_element = list(),
 #'               first_name = 'Katherine', 

--- a/R/personnel-element.R
+++ b/R/personnel-element.R
@@ -28,11 +28,12 @@
 #'               organization = 'IBM')
 #' @export
 add_personnel <- function(parent_element, first_name, last_name, email, 
-                          role, orcid = NULL, organization = NULL) {
+                          role, organization, orcid = NULL) {
   
-  required_arguments <- c("first_name", "last_name", "email", "role")
+  required_arguments <- c("first_name", "last_name", "email", "role", "organization")
   missing_argument_index <- which(c(missing(first_name), missing(last_name), 
-                                missing(email), missing(role)))
+                                missing(email), missing(role), 
+                                missing(organization)))
   
   if (length(missing_argument_index) > 0) {
     person_error <- required_arguments[missing_argument_index][1]
@@ -40,20 +41,15 @@ add_personnel <- function(parent_element, first_name, last_name, email,
                                    first_name = "Please supply a first name.",
                                    last_name = "Please supply a last name.",
                                    email = "Please supply an email.",
-                                   role = "Please supply a role. Use 'creator' if you are the main originator of the dataset or project")
+                                   role = "Please supply a role. Use 'creator' if you are the main originator of the dataset or project",
+                                   organization = "Please supply the name of the organization employing the personnel")
     stop(person_error_message, call. = FALSE)
   } 
   
-  person <- list(individualName = 
-                   list(givenName = first_name, 
-                        surName = last_name),
-                 electronicMailAddress = email)
-  
-  
-  
-  if (!is.null(organization)) {
-    person$organizationName <- organization
-  }
+  person <- list(individualName = list(givenName = first_name, 
+                                       surName = last_name),
+                 electronicMailAddress = email, 
+                 organizationName = organization)
   
   if (tolower(role) == "creator") {
     parent_element$contact <- person

--- a/man/add_personnel.Rd
+++ b/man/add_personnel.Rd
@@ -10,8 +10,8 @@ add_personnel(
   last_name,
   email,
   role,
-  orcid = NULL,
-  organization = NULL
+  organization,
+  orcid = NULL
 )
 }
 \arguments{
@@ -27,11 +27,11 @@ add_personnel(
 Other possible roles "Data Manager", "Field Technician", or "Assistant Researcher".
 There can be multiple personnel on a project with the same role.}
 
-\item{orcid}{ORCID iD is a persistent digital identifier for researchers,
-register at \url{http://orcid.org/}}
-
 \item{organization}{Person's employer or the entity they are associated
 with for this dataset or project}
+
+\item{orcid}{ORCID iD is a persistent digital identifier for researchers,
+register at \url{http://orcid.org/}}
 }
 \description{
 Adds personel according to EML standards

--- a/tests/testthat/test-eml-elements.R
+++ b/tests/testthat/test-eml-elements.R
@@ -93,56 +93,86 @@ test_that('personnel function errors when missing mandatory identifier inputs', 
   organization <- "USFWS"
  
   expect_error(add_personnel(parent_element = parent_element, role = role1, 
-                             first_name = first_name, last_name = last_name),
+                             first_name = first_name, last_name = last_name,
+                             organization = oganization),
                "Please supply an email.")
+  
   expect_error(add_personnel(parent_element = parent_element, role = role1, 
-                             first_name = first_name, email = email),
+                             first_name = first_name, email = email, 
+                             organization = organization),
                "Please supply a last name.")
+  
   expect_error(add_personnel(parent_element = parent_element, role = role1, 
-                             last_name = last_name, email = email), 
+                             last_name = last_name, email = email,
+                             organization = organization), 
                "Please supply a first name.")
+  
   expect_error(add_personnel(parent_element = parent_element, first_name = first_name, 
-                             last_name = last_name, email = email), 
+                             last_name = last_name, email = email, 
+                             organization = organization), 
                "Please supply a role. Use 'creator' if you are the main originator of the dataset or project")
   
+  expect_error(add_personnel(parent_element = parent_element, first_name = first_name, 
+                             last_name = last_name, role = role, email = email), 
+               "Please supply the name of the organization employing the personnel")
+  
   expect_equal(add_personnel(parent_element = parent_element, first_name = first_name, 
-                             last_name = last_name, email = email, role = role1, orcid = orcid),
+                             last_name = last_name, email = email, role = role1, 
+                             organization = organization, orcid = orcid),
                list(contact = list(individualName = list(givenName = "Susan", 
-                                                         surName = "Susanton"), electronicMailAddress = "susanton@fake.com"), 
+                                                         surName = "Susanton"), 
+                                   electronicMailAddress = "susanton@fake.com",
+                                   organizationName = "USFWS"), 
                     creator = list(individualName = list(givenName = "Susan", 
-                                                         surName = "Susanton"), electronicMailAddress = "susanton@fake.com", 
+                                                         surName = "Susanton"), 
+                                   electronicMailAddress = "susanton@fake.com", 
+                                   organizationName = "USFWS",
                                    `@id` = "00110011")))
   
   expect_equal(add_personnel(parent_element = parent_element, first_name = first_name,
-                             last_name = last_name, email = email, role = role2, orcid = orcid,
-                             organization = organization),
+                             last_name = last_name, email = email, role = role2, 
+                             orcid = orcid, organization = organization),
                list(associatedParty = list(individualName = list(givenName = "Susan", 
-                                                                 surName = "Susanton"), electronicMailAddress = "susanton@fake.com", 
+                                                                 surName = "Susanton"), 
+                                           electronicMailAddress = "susanton@fake.com", 
                                            organizationName = "USFWS", role = "Data Manager")))
   
   creator_1 <- add_personnel(parent_element = parent_element, first_name = first_name, 
-                             last_name = last_name, email = email, role = role1)
+                             last_name = last_name, email = email, role = role1,
+                             organization = organization)
   
   expect_equal(add_personnel(parent_element = creator_1, first_name = "Not Susan", 
-                             last_name = "Smith", email = "free_cats@aol.com", role = role1),
+                             last_name = "Smith", email = "free_cats@aol.com", 
+                             organization = organization, role = role1),
                list(contact = list(individualName = list(givenName = "Not Susan", 
-                                                         surName = "Smith"), electronicMailAddress = "free_cats@aol.com"), 
+                                                         surName = "Smith"), 
+                                   electronicMailAddress = "free_cats@aol.com",
+                                   organizationName = "USFWS"), 
                     creator = list(list(individualName = list(givenName = "Susan", 
-                                                              surName = "Susanton"), electronicMailAddress = "susanton@fake.com"), 
-                                   list(individualName = list(givenName = "Not Susan", surName = "Smith"), 
-                                        electronicMailAddress = "free_cats@aol.com"))))
+                                                              surName = "Susanton"), 
+                                        electronicMailAddress = "susanton@fake.com",
+                                        organizationName = "USFWS"), 
+                                   list(individualName = list(givenName = "Not Susan", 
+                                                              surName = "Smith"), 
+                                        electronicMailAddress = "free_cats@aol.com",
+                                        organizationName = "USFWS"))))
   
   data_manager_1 <- add_personnel(parent_element = parent_element, first_name = first_name, 
-                                  last_name = last_name, email = email, role = role2)
+                                  last_name = last_name, email = email, role = role2,
+                                  organization = organization)
   
   expect_equal(add_personnel(parent_element = data_manager_1, first_name = "Not Susan", 
-                             last_name = "Smith", email = "free_cats@aol.com", role = role2),
+                             last_name = "Smith", email = "free_cats@aol.com", role = role2,
+                             organization = organization),
                list(associatedParty = list(list(individualName = list(givenName = "Susan", 
                                                                       surName = "Susanton"), 
                                                 electronicMailAddress = "susanton@fake.com", 
+                                                organizationName = "USFWS",
                                                 role = "Data Manager"), 
-                                           list(individualName = list(givenName = "Not Susan", surName = "Smith"), 
+                                           list(individualName = list(givenName = "Not Susan", 
+                                                                      surName = "Smith"), 
                                                 electronicMailAddress = "free_cats@aol.com", 
+                                                organizationName = "USFWS",
                                                 role = "Data Manager"))))
   
   


### PR DESCRIPTION
I made the organization attribute required for the add_personnel function. The EML schema requires that you include a persons organization. 