### PR TITLE
Fix messaging

### DIFF
--- a/R/attribute-element.R
+++ b/R/attribute-element.R
@@ -160,9 +160,7 @@ create_attribute <- function(attribute_name, attribute_definition, storage_type,
                     attributeDefinition = attribute_definition,
                     storageType = storage_type)
   
-  if (missing(attribute_label)) {
-    message('No attribute label provided.')
-  } else {
+  if (!missing(attribute_label)) {
    attribute$attributeLabel <- attribute_label
   }
   
@@ -239,9 +237,7 @@ create_nominal <- function(domain = c("text", "enumerated"), definition, text_pa
   if (domain == "text") {
     measurementScale$nominal$nonNumericDomain$textDomain$definition <- definition
     
-    if (is.null(text_pattern)) {
-      message('Warning: Please add text pattern if applicable.')
-    } else { 
+    if (!is.null(text_pattern)) {
       measurementScale$nominal$nonNumericDomain$textDomain$pattern <- text_pattern
     }
     
@@ -293,9 +289,7 @@ create_ordinal <- function(domain = c("text", "enumerated"), definition, text_pa
   if (domain == "text") {
     measurementScale$ordinal$nonNumericDomain$textDomain$definition <- definition
     
-    if (is.null(text_pattern)) {
-      message('Warning: Please add text pattern if applicable.')
-    } else { 
+    if (!is.null(text_pattern)) {
       measurementScale$ordinal$nonNumericDomain$textDomain$pattern <- text_pattern
     }
     

--- a/R/title-element.R
+++ b/R/title-element.R
@@ -18,7 +18,7 @@ create_title <- function(title, short_name) {
   short_name_number_of_words <- length(unlist(strsplit(short_name, " "))) 
   
   if (title_number_of_words < 7 | title_number_of_words > 20) {
-    stop("Please make sure your title is between 7 and 20 words long.")
+    warning("Please make sure your title is between 7 and 20 words long.")
   }
   
   if (short_name_number_of_words >= title_number_of_words) {

--- a/tests/testthat/test-data-table-elements.R
+++ b/tests/testthat/test-data-table-elements.R
@@ -12,11 +12,6 @@ test_that('Correct error and warning messages are produced.', {
                              domain = "text", definition = "Latitude", text_pattern = "Latitudes"),
                'Please provide a brief definition of the attribute you are including.')
   
-  expect_message(create_attribute(attribute_name = "LatitudeDD", attribute_definition = "Latitude",
-                               storage_type = "coordinate", measurement_scale = "ordinal",
-                               domain = "text", definition = "Latitude", text_pattern = "Latitudes"),
-                 'No attribute label provided.')
-  
   expect_error(create_attribute(attribute_name = "LatitudeDD", attribute_definition = "Latitude",
                              attribute_label = "Lat", measurement_scale = "ordinal",
                              domain = "text", definition = "Latitude", text_pattern = "Latitudes"),
@@ -31,11 +26,7 @@ test_that('Correct error and warning messages are produced.', {
                              attribute_label = "Lat", storage_type = "coordinate", measurement_scale = "ordinal",
                              domain = "text", text_pattern = "Latitudes"),
                'Please provide the description for your measurement scale.')
-  
-  expect_message(create_attribute(attribute_name = "LatitudeDD", attribute_definition = "Latitude",
-                               attribute_label = "Lat", storage_type = "coordinate", measurement_scale = "ordinal",
-                               domain = "text", definition = "Latitude"),
-                 'Warning: Please add text pattern if applicable.')
+
   
   expect_error(create_attribute(attribute_name = "site_id", attribute_label = "sites", 
                              attribute_definition = "Site id as used in sites table",
@@ -48,12 +39,6 @@ test_that('Correct error and warning messages are produced.', {
                              storage_type = "string", measurement_scale = "nominal",
                              definition = "Sites", text_pattern = "ids"),
                'Please provide a domain of "text" or "enumerated" and supply the remaining applicable inputs.')
-  
-  expect_message(create_attribute(attribute_name = "site_id", attribute_definition = "Site id as used in sites table",
-                               storage_type = "string", measurement_scale = "nominal",
-                               domain = "text", attribute_label = "sites",
-                               definition = "Site id as used in sites table."),
-                 'Warning: Please add text pattern if applicable.')
   
   expect_error(create_attribute(attribute_name = "Recap", attribute_definition = "Has the Turtle been captured and tagged previously",
                              storage_type = "text", attribute_label = "Turtles",
@@ -70,12 +55,6 @@ test_that('Correct error and warning messages are produced.', {
                              attribute_label = "Latitude", storage_type = "coordinate",
                              measurement_scale = "ordinal", domain = "text", text_pattern = "NA"),
                'Please provide the description for your measurement scale.')
-  
-  expect_message(create_attribute(attribute_name = "LatitudeDD", attribute_definition = "Latitude",
-                               attribute_label = "Latitude", storage_type = "coordinate",
-                               measurement_scale = "ordinal",
-                               domain = "text", definition = "Latitude"),
-                 'Warning: Please add text pattern if applicable.')
   
   expect_error(create_attribute(attribute_name = "hwa", attribute_definition = "Hemlock woolly adelgid density per meter of branch",
                              storage_type = "number", measurement_scale = "ordinal",

--- a/tests/testthat/test-eml-elements.R
+++ b/tests/testthat/test-eml-elements.R
@@ -22,7 +22,7 @@ test_that('dataset title length is between 7 and 20 words long', {
   
   expect_gte(length(unlist(strsplit(passing_dataset$title, split = " "))), 7)
   
-  expect_error(
+  expect_warning(
     create_title(title = "Too long title lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ante ipsum, consectetur quis iaculis eget, rhoncus rutrum velit. Donec cursus massa non.",
               short_name = "This is a short name for this dataset"),
     "Please make sure your title is between 7 and 20 words long."
@@ -31,12 +31,12 @@ test_that('dataset title length is between 7 and 20 words long', {
   expect_error(
     create_title(title = "Too short title.",
               short_name = "This is a short name for this dataset"),
-    "Please make sure your title is between 7 and 20 words long."
+    "Short name should not be longer than the dataset's title."
   )
   
   expect_error(
     create_title(title = "This title is at least 7 words and not over 20 words.",
-              short_name = "This is a short name and it is way way way way way way way way way way way way way way way way way way too long."),
+                 short_name = "This is a short name and it is way way way way way way way way way way way way way way way way way way too long."),
     "Short name should not be longer than the dataset's title."
   )
   


### PR DESCRIPTION
closes #122 

Removed warnings that I felt were unnecessary (and annoying) from the `create_attribute()` function. This removes warnings from the `create_datatable()` functions as well. 